### PR TITLE
*DO NOT MERGE* add workflow for repo sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,25 @@
+name: Repo Sync
+
+on:
+  schedule: 
+  - cron: '0 0 * * *'
+
+jobs:
+  repo-sync:
+    name: Repo Sync
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout public repo code
+      uses: actions/checkout@v3
+    - name: Set up Git configuration
+      run: |
+        git config --global user.name "${{ secrets.GIT_USER_NAME }}"
+        git config --global user.email "${{ secrets.GIT_USER_EMAIL }}"
+    - name: Sync code from internal repo to public repo main branch 
+      uses: repo-sync/github-sync@v2
+      with:
+        source_repo: ${{ secrets.SOURCE_REPO }}
+        source_branch: main
+        destination_branch: main
+        github_token: ${{ secrets.WORKFLOW_TOKEN }}
+


### PR DESCRIPTION
Before merging this PR we need to set the secret variables required for the workflow. 
And also add branch protection rules.